### PR TITLE
Delete useless config

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -9,7 +9,6 @@ ray:
   cluster:
     host: localhost
     port: 4000
-    num_cpus: 6
   dashboard:
     host: localhost
     port: 8265

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -19,6 +19,7 @@ kowalski:
   port: 443
   token: <your_token_here>
   alert_stream: ZTF_alerts
+  number_of_processes: 12
 
 params:
   max_queries_per_batch: 10000

--- a/src/fetch_matching_alerts/fetch_matching_alerts.py
+++ b/src/fetch_matching_alerts/fetch_matching_alerts.py
@@ -102,7 +102,7 @@ def fetch_comet_matching_alerts(
                 kowalski,
                 queries=queries,
                 query_type="cone_search",
-                n_processes=cfg["kowalski.number_of_processes"],
+                n_processes=cfg.get("kowalski.number_of_processes"),
                 stream=stream,
                 seen_ids_by_comet=seen_ids_by_comet,
             )

--- a/src/fetch_matching_alerts/fetch_matching_alerts.py
+++ b/src/fetch_matching_alerts/fetch_matching_alerts.py
@@ -17,7 +17,6 @@ cfg = load_config()
 
 def fetch_comet_matching_alerts(
     kowalski,
-    n_processes,
     verbose,
 ):
     # Load comet positions already fetched
@@ -103,7 +102,7 @@ def fetch_comet_matching_alerts(
                 kowalski,
                 queries=queries,
                 query_type="cone_search",
-                n_processes=n_processes,
+                n_processes=cfg["kowalski.number_of_processes"],
                 stream=stream,
                 seen_ids_by_comet=seen_ids_by_comet,
             )

--- a/src/fetch_matching_alerts/fetch_matching_alerts_ray.py
+++ b/src/fetch_matching_alerts/fetch_matching_alerts_ray.py
@@ -7,7 +7,6 @@ from src.fetch_matching_alerts.fetch_matching_alerts import fetch_comet_matching
 
 @ray.remote
 def fetch_comet_matching_alerts_remote(
-    n_processes=12,
     verbose=True,
     loop=False,
 ):
@@ -17,14 +16,12 @@ def fetch_comet_matching_alerts_remote(
         while True:
             fetch_comet_matching_alerts(
                 kowalski,
-                n_processes,
                 verbose,
             )
             time.sleep(60)
     else:
         fetch_comet_matching_alerts(
             kowalski,
-            n_processes,
             verbose,
         )
 

--- a/src/utils/kowalski.py
+++ b/src/utils/kowalski.py
@@ -105,7 +105,7 @@ def run_queries(
         query_results (dict): query results
     """
     responses = kowalski.query(
-        queries=queries, use_batch_query=True, max_n_threads=n_processes
+        queries=queries, use_batch_query=True, max_n_threads=n_processes or 4
     )
     if query_type != "cone_search":
         raise NotImplementedError(f"query_type {query_type} not implemented yet!")


### PR DESCRIPTION
Delete useless config and add a config variable to manage the number of process use for the kowalski call.